### PR TITLE
feat: remove pro ads

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -30,9 +30,10 @@ export class Bot implements BotProtocol {
       ])
 
       this.model = new ChatOpenAI({
-        temperature: options.openaiModelTemperature,
+        modelName: openaiOptions.model,
         maxTokens: openaiOptions.tokenLimits.responseTokens,
         openAIApiKey: process.env.OPENAI_API_KEY,
+        temperature: this.options.openaiModelTemperature,
         timeout: this.options.openaiTimeoutMS,
         maxRetries: this.options.openaiRetries,
         configuration: {

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -24,6 +24,14 @@ export class TokenLimits {
         this.maxTokens = 16300
         this.responseTokens = 3000
         break
+      case 'Groq: Mixtral 8x7b':
+        this.maxTokens = 32768
+        this.responseTokens = 4000
+        break
+      case 'Gemini 1.5 Pro':
+        this.maxTokens = 1048576
+        this.responseTokens = 8000
+        break
       default:
         this.maxTokens = 4000
         this.responseTokens = 1000

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -25,11 +25,11 @@ export class TokenLimits {
         this.responseTokens = 3000
         break
       case 'Groq: Mixtral 8x7b':
-        this.maxTokens = 32768
+        this.maxTokens = 32000
         this.responseTokens = 4000
         break
       case 'Gemini 1.5 Pro':
-        this.maxTokens = 1048576
+        this.maxTokens = 1000000
         this.responseTokens = 8000
         break
       default:

--- a/src/review.ts
+++ b/src/review.ts
@@ -450,14 +450,6 @@ ${SHORT_SUMMARY_END_TAG}
 
 ---
 
-<details>
-<summary>Uplevel your code reviews with CodeRabbit Pro</summary>
-
-### CodeRabbit Pro
-
-If you like this project, please support us by purchasing the [Pro version](https://coderabbit.ai). The Pro version has advanced context, superior noise reduction and several proprietary improvements compared to the open source version. Moreover, CodeRabbit Pro is free for open source projects.
-
-</details>
 `
 
   statusMsg += `


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

## Walkthrough

This pull request streamlines the code by removing the `proAds` feature and refining the `ChatOpenAI` setup process. While these changes primarily impact the internal workings of the bot, it's essential to ensure they don't introduce any unexpected issues or vulnerabilities. 

## Changes

| File(s) | Summary |
|---|---|
| src/bot.ts | This changeset removes the `proAds` feature and modifies the `ChatOpenAI` instantiation by changing the source and name of the `temperature` property and moving its assignment location. |


> **Ode to Code** 🐇 💻 

> Lines that dance and logic that flows, 
> Bugs squashed and features that grow. 
> Code evolves with each careful tweak, 
> A symphony of progress, sleek. 
> 
> With every commit, a step we take, 
> Towards a brighter future, we bake. 
> A digital world, our canvas to paint, 
> With code as our brush, we create and we taint. 🎨 ✨
## Release Notes

This release focuses on internal code improvements:

- **Refactor:** Removed the `proAds` feature.
- **Refactor:** Streamlined the `ChatOpenAI` setup process. 

These changes enhance the code's maintainability and efficiency while ensuring a smooth user experience. 

<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->